### PR TITLE
Fix link to item when domain is null

### DIFF
--- a/src/hn-list.html
+++ b/src/hn-list.html
@@ -97,8 +97,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <li>
           <span class="index">[[_computeIndex(pageSize, page, index)]]</span>
           <div class="title">
-            <a href="[[item.url]]">[[item.title]]</a>
-            <span class="domain">([[item.domain]])</span>
+            <a href="[[_computeUrl(item)]]">[[item.title]]</a>
+            <span class="domain" hidden$="[[!item.domain]]">([[item.domain]])</span>
             <div class="info">
               [[item.points]] points by
               <a href="/user/[[item.user]]">[[item.user]]</a>
@@ -141,6 +141,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       _computeIndex(pageSize, page, index) {
         return pageSize * (page - 1) + index + 1;
+      }
+
+      _computeUrl(item) {
+        return item.domain ? item.url : ("/item/" + item.id);
       }
     }
 


### PR DESCRIPTION
When a list item doesn't have a `domain` the anchor element gets an invalid URL (probably server side API changed?). But it is possible to create a valid URL for that item using `"/item/" + item.id`.

I've also removed empty parentheses from title using item `domain` property.